### PR TITLE
fix: alter s3 bucket creation terraform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,9 @@ resource "random_pet" "lambda_bucket_name" {
 
 resource "aws_s3_bucket" "lambda_bucket" {
   bucket = random_pet.lambda_bucket_name.id
+}
 
-  acl           = "private"
-  force_destroy = true
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  bucket = aws_s3_bucket.lambda_bucket.id
+  acl    = "private"
 }


### PR DESCRIPTION
In Terraform AWS Provider v4.0.0, the code currently being used causes an error. Changing it to the following fixes the issue: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket