### PR TITLE
Error: Value for unconfigurable attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,5 @@ resource "random_pet" "lambda_bucket_name" {
 resource "aws_s3_bucket" "lambda_bucket" {
   bucket = random_pet.lambda_bucket_name.id
 
-  acl           = "private"
   force_destroy = true
 }


### PR DESCRIPTION
when the validation command is executed, the current code not working because we can't configure a value for "acl": its value will be decided automatically based on the result of applying this configuration

`terraform validate`

then 

`│ Error: Value for unconfigurable attribute
│ 
│   with aws_s3_bucket.lambda_bucket,
│   on main.tf line 32, in resource "aws_s3_bucket" "lambda_bucket":
│   32:   acl           = "private"
│ 
│ Can't configure a value for "acl": its value will be decided automatically based on the result of applying this configuration.`