### PR TITLE
Add independent resource for s3 acl

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,3 +32,8 @@ resource "aws_s3_bucket" "lambda_bucket" {
   acl           = "private"
   force_destroy = true
 }
+
+resource "aws_s3-bucket_acl" "lambda_bucket_acl" {
+  bucket = random_pet.lambda_bucket_name.id
+  acl    = "private"
+}


### PR DESCRIPTION
Fix for issues: https://github.com/hashicorp/learn-terraform-lambda-api-gateway/issues/4 and https://github.com/hashicorp/learn-terraform-lambda-api-gateway/issues/8

As per provider docs for [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) acl attribute is deprecated. ACL can be configured as a standalone resource [aws_s3_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl)